### PR TITLE
remove all toasts before turbolinks cache it

### DIFF
--- a/app/assets/javascripts/init.coffee
+++ b/app/assets/javascripts/init.coffee
@@ -5,6 +5,9 @@ $(document).on 'turbolinks:before-visit turbolinks:before-cache', ->
     instance.close() if instance.isOpen #close on click
     instance.destroy()
 
+$(document).on 'turbolinks:before-visit turbolinks:before-cache', ->
+  $('.toast').remove()
+
 $(document).on 'turbolinks:load', ->
   elem = document.querySelector('#slide-out');
   instance = new M.Sidenav(elem, {}) if elem


### PR DESCRIPTION
When navigating back and forth in the browser, the rendered toast will remain permanently and can't be dismissed as it's not a material toast element. Destroying/removing the element would make more sense, because the 'dismissAll' function takes too long to complete and won't fully remove the toast from the DOM. Furthermore, you have to prevent turbolinks from recreating the toast:

```
if (!(document.documentElement.hasAttribute("data-turbolinks-preview"))) {
        M.toast({html: "Whatever", classes: "red darken-1"});
}
```